### PR TITLE
Updates of POM and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ You can run this directly from IDE, or cd to deepdsl-java folder and run from co
 [Lenet.java]: <https://github.com/deepdsl/deepdsl/tree/master/deepdsl-java/src/main/java/deepdsl/gen/Lenet.java>
 [Alexnet.java]: <https://github.com/deepdsl/deepdsl/tree/master/deepdsl-java/src/main/java/deepdsl/gen/Alexnet.java>
 
-[dataset/mnist/]: <https://github.com/deepdsl/deepdsl/tree/master/deepdsl-java/dataset/mnist>
+[dataset/mnist/]: <https://github.com/deepdsl/deepdsl/tree/master/deepdsl-java/dataset/mnist/>
 [dataset/imagenet/]: <https://github.com/deepdsl/deepdsl/tree/master/deepdsl-java/dataset/imagenet/>
 [Caffe's imagenet script]: <https://github.com/BVLC/caffe/tree/master/examples/imagenet>
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Please refer to our paper draft [DeepDSL] for full details.
 - To run test cases and compiled code for different networks, you also need to: 
   - have a [Nvidia CUDA] enabled GPU machine  
   - install 8.X version of [CUDA Toolkit 8.0] and [cuDNN 5] libraries
+  - make sure that the cuDNN library is visible for Java. 
+    On Windows, the path that contains the `cudnn64_5.dll` has to be added to the `PATH` environment variable. 
+    On Linux, the path that contains the ` libcudnn.so.5` has be added to the `LD_LIBRARY_PATH`
 
 ### Maven Build (Need to be executed the below in the root folder of the project)
 - Windows build: mvn -Pwin64 clean install
@@ -46,7 +49,7 @@ After the previous Maven Build step, you can cd to the deepdsl-java folder and r
 There are two util Python scripts under the folder src/main/python (both should be run from the deepdsl project root folder).
 
 - mnist_data_handler.py: download the mnist data and unzip to the `dataset/mnist` folder
-     - to run: `python src/main/python/mnist_data_handler.py`, this will pull and extract the mnist dataset to `dataset/mnist`
+     - to run: `python ../src/main/python/mnist_data_handler.py` (called in the `deepdsl-java` directory). This will pull and extract the mnist dataset to `dataset/mnist`
 - imagenet_data_selector.py: to select given number of images of given number of categories from the original imagenet data
      - to run: `python src/main/python/imagenet_data_selector.py` and then follow the on-screen instructions to apply the desired parameters and run again
         - For example, `python imagenet_data_selector.py ~/data/ILSVRC2012_img_train ~/data/temp 5 50 0.3 0.2`, which selects from 5 categories (50 images per catetory) from ~/data/ILSVRC2012_img_train folder and stores selected images to ~/data/temp folder, where 30% are stored as validation dataset and 20% are stored as test dataset
@@ -54,7 +57,7 @@ There are two util Python scripts under the folder src/main/python (both should 
 ### Default location for training and testing data
 Each program assumes a location for the training and test data. 
 
-- [Lenet.java] uses Mnist, which is assumed to be located at [dataset/mnist] (please use the script described in the previous section to prepare the dataset).
+- [Lenet.java] uses Mnist, which is assumed to be located at [dataset/mnist/] (please use the script described in the previous section to prepare the dataset).
 - Other programs such as [Alexnet.java] use imagenet (as Lmdb database), which is assumed to be located at "[dataset/imagenet/]ilsvrc12_train_lmdb" for training data and "[dataset/imagenet/]ilsvrc12_val_lmdb" for testing data, where the image sizes are cropped to 224 x 224. Other image sizes should also work since we would randomly cropped the training images to the right size while cropping the testing images at center.
      - Users currently may use tools like [Caffe's imagenet script] `examples/imagenet/create_imagenet.sh` to create the lmdb data from the original Imagenet dataset. Please hang tight, we are adding our scripts soon so you don't have to resort to outside reources.
 - For Lmdb data source, users may edit the call to [LmdbFactory].getFactory in the generated Java source to change the max number of training images and test images. The current default is 1000,000 and 10,000 respectively. 
@@ -158,7 +161,7 @@ You can run this directly from IDE, or cd to deepdsl-java folder and run from co
      - No worry. DeepDSL is designed to save your execution result automatically (Indeed, if you run the same program again, DeepDSL will 
      automatically pick up where you left off last time and start training the model from there!). You just need to let DeepDSL know where 
      to save! In the above example, the code is trying to store the trained model for Alexnet execution, therefore you need to create a 
-     folder "src/main/java/deepdsl/gen/alexnet‚Äù before you run the program, otherwise you lose it. Please refer to the 
+     folder `src/main/java/deepdsl/gen/alexnet`ù before you run the program, otherwise you lose it. Please refer to the 
      [Default location for trained parameters](#default-loc) section for more details.   
 
 [JCuda]: <http://jcuda.org/>
@@ -172,7 +175,7 @@ You can run this directly from IDE, or cd to deepdsl-java folder and run from co
 [Lenet.java]: <https://github.com/deepdsl/deepdsl/tree/master/deepdsl-java/src/main/java/deepdsl/gen/Lenet.java>
 [Alexnet.java]: <https://github.com/deepdsl/deepdsl/tree/master/deepdsl-java/src/main/java/deepdsl/gen/Alexnet.java>
 
-[dataset/mnist]: <https://github.com/deepdsl/deepdsl/tree/master/deepdsl-java/dataset/mnist>
+[dataset/mnist/]: <https://github.com/deepdsl/deepdsl/tree/master/deepdsl-java/dataset/mnist>
 [dataset/imagenet/]: <https://github.com/deepdsl/deepdsl/tree/master/deepdsl-java/dataset/imagenet/>
 [Caffe's imagenet script]: <https://github.com/BVLC/caffe/tree/master/examples/imagenet>
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ There are two util Python scripts under the folder src/main/python (both should 
 ### Default location for training and testing data
 Each program assumes a location for the training and test data. 
 
-- [Lenet.java] uses Mnist, which is assumed to be located at [dataset/mnist/] (please use the script described in the previous section to prepare the dataset).
+- [Lenet.java] uses Mnist, which is assumed to be located at [dataset/mnist/](https://github.com/deepdsl/deepdsl/tree/master/deepdsl-java/dataset/mnist/) (please use the script described in the previous section to prepare the dataset).
 - Other programs such as [Alexnet.java] use imagenet (as Lmdb database), which is assumed to be located at "[dataset/imagenet/]ilsvrc12_train_lmdb" for training data and "[dataset/imagenet/]ilsvrc12_val_lmdb" for testing data, where the image sizes are cropped to 224 x 224. Other image sizes should also work since we would randomly cropped the training images to the right size while cropping the testing images at center.
      - Users currently may use tools like [Caffe's imagenet script] `examples/imagenet/create_imagenet.sh` to create the lmdb data from the original Imagenet dataset. Please hang tight, we are adding our scripts soon so you don't have to resort to outside reources.
 - For Lmdb data source, users may edit the call to [LmdbFactory].getFactory in the generated Java source to change the max number of training images and test images. The current default is 1000,000 and 10,000 respectively. 
@@ -134,7 +134,7 @@ You can run this directly from IDE, or cd to deepdsl-java folder and run from co
 - What if my maven build / execution process gives me "Caused by: jcuda.CudaException: CUDA_ERROR_UNKNOWN" like error?    
      - This means your installation of CUDA is not complete or correct. Please follow the [CUDA installation checking link] to verify and reinstall.
 - I can build the project successfully (e.g. with "mvn -Plinux64 clean install") but I received "Caused by: org.fusesource.lmdbjni.LMDBException: No such file or directory" when I run "mvn -Plinux64 exec:java -Dexec.mainClass="deepdsl.gen.Alexnet"", what should I do?
-     - Congratulations, you are actually very close to run the examples. The only thing you need is to have some Imagenet data in the LMDB format. You receive the attached error because you don’t have the llmdb imagenet dataset in place. Please read the section "Default location for training and testing data" in this page for details on how to download the dataset and convert it to the Caffe lmdb format. Again, you need to put lmdb files to the assumed folder “dataset/imagenet/ilsvrc12_train_lmdb”.
+     - Congratulations, you are actually very close to run the examples. The only thing you need is to have some Imagenet data in the LMDB format. You receive the attached error because you don't have the llmdb imagenet dataset in place. Please read the section "Default location for training and testing data" in this page for details on how to download the dataset and convert it to the Caffe lmdb format. Again, you need to put lmdb files to the assumed folder `dataset/imagenet/ilsvrc12_train_lmdb`.
 - I can run the generated code, such as Alexnet128, however, I received exception as shown below when the execution finishes, what am I supposed to do?
  
     ```
@@ -175,8 +175,8 @@ You can run this directly from IDE, or cd to deepdsl-java folder and run from co
 [Lenet.java]: <https://github.com/deepdsl/deepdsl/tree/master/deepdsl-java/src/main/java/deepdsl/gen/Lenet.java>
 [Alexnet.java]: <https://github.com/deepdsl/deepdsl/tree/master/deepdsl-java/src/main/java/deepdsl/gen/Alexnet.java>
 
-[dataset/mnist/]: <https://github.com/deepdsl/deepdsl/tree/master/deepdsl-java/dataset/mnist/>
-[dataset/imagenet/]: <https://github.com/deepdsl/deepdsl/tree/master/deepdsl-java/dataset/imagenet/>
+
+[dataset/imagenet/]: <>
 [Caffe's imagenet script]: <https://github.com/BVLC/caffe/tree/master/examples/imagenet>
 
 [Apache Maven]: <https://maven.apache.org/download.cgi>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
                 <version>2.8.0</version>
             </dependency>
             <!--
-                local dependencies
+                JCuda dependencies
             -->
             <dependency>
                 <groupId>org.naokishibata.sleef</groupId>
@@ -71,53 +71,22 @@
             <dependency>
                 <groupId>org.jcuda</groupId>
                 <artifactId>jcudnn</artifactId>
-                <version>0.8.0RC</version>
+                <version>0.8.0</version>
             </dependency>
             <dependency>
                 <groupId>org.jcuda</groupId>
                 <artifactId>jcuda</artifactId>
-                <version>0.8.0RC</version>
+                <version>0.8.0</version>
             </dependency>
             <dependency>
                 <groupId>org.jcuda</groupId>
                 <artifactId>jcublas</artifactId>
-                <version>0.8.0RC</version>
+                <version>0.8.0</version>
             </dependency>
             <dependency>
                 <groupId>org.jcuda</groupId>
                 <artifactId>jcuda-vec</artifactId>
-                <version>0.0.1</version>
-            </dependency>
-            <!-- native dependencies -->
-            <dependency>
-                <groupId>org.jcuda</groupId>
-                <artifactId>jcuda-natives</artifactId>
-                <version>0.8.0RC-linux-x86_64</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jcuda</groupId>
-                <artifactId>jcublas-natives</artifactId>
-                <version>0.8.0RC-linux-x86_64</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jcuda</groupId>
-                <artifactId>jcudnn-natives</artifactId>
-                <version>0.8.0RC-linux-x86_64</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jcuda</groupId>
-                <artifactId>jcuda-natives</artifactId>
-                <version>0.8.0RC-windows-x86_64</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jcuda</groupId>
-                <artifactId>jcublas-natives</artifactId>
-                <version>0.8.0RC-windows-x86_64</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jcuda</groupId>
-                <artifactId>jcudnn-natives</artifactId>
-                <version>0.8.0RC-HOTFIX01-windows-x86_64</version>
+                <version>0.0.2</version>
             </dependency>
             <!--
                 test dependencies
@@ -143,24 +112,6 @@
                     <groupId>org.deephacks.lmdbjni</groupId>
                     <artifactId>lmdbjni-win64</artifactId>
                 </dependency>
-                <dependency>
-                    <groupId>org.jcuda</groupId>
-                    <artifactId>jcuda-natives</artifactId>
-                    <version>0.8.0RC-windows-x86_64</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.jcuda</groupId>
-                    <artifactId>jcublas-natives</artifactId>
-                    <version>0.8.0RC-windows-x86_64</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.jcuda</groupId>
-                    <artifactId>jcudnn-natives</artifactId>
-                    <version>0.8.0RC-HOTFIX01-windows-x86_64</version>
-                    <scope>test</scope>
-                </dependency>
             </dependencies>
         </profile>
         <profile>
@@ -169,24 +120,6 @@
                 <dependency>
                     <groupId>org.deephacks.lmdbjni</groupId>
                     <artifactId>lmdbjni-linux64</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>org.jcuda</groupId>
-                    <artifactId>jcuda-natives</artifactId>
-                    <version>0.8.0RC-linux-x86_64</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.jcuda</groupId>
-                    <artifactId>jcublas-natives</artifactId>
-                    <version>0.8.0RC-linux-x86_64</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.jcuda</groupId>
-                    <artifactId>jcudnn-natives</artifactId>
-                    <version>0.8.0RC-linux-x86_64</version>
-                    <scope>test</scope>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
The POM has been updated to refer to the latest JCuda version, which is available in Maven Central (as well as an initial, early release of `jcuda-vec-0.0.2`).

Some minor issues in the README have been fixed: Some links had been broken (due to details of the GitHub link syntax that I did not investigate further). If you prefer to not apply these changes, I can create a dedicated PR only for the POM.

A side note: When the missing `gen/...` directories are causing people to receive a `FileNotFoundException`, wouldn't it make sense to either 
- create these (empty) directories in the repo **or** 
- (better: ) make sure that the directories are created when they are needed
?
